### PR TITLE
Serializable `AccountInfo`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-dist
-node_modules
+dist/
+node_modules/
+
+.DS_Store
+.idea/
+.vscode/

--- a/src/AccountInfo.ts
+++ b/src/AccountInfo.ts
@@ -1,0 +1,69 @@
+import {
+  AccountAddress, AccountAddressInput, AnyPublicKey,
+  Deserializer,
+  Ed25519PublicKey,
+  MultiEd25519PublicKey, MultiKey,
+  PublicKey,
+  Serializable,
+  Serializer, SigningScheme
+} from '@aptos-labs/ts-sdk'
+
+export interface AccountInfoInput {
+  address: AccountAddressInput
+  publicKey: PublicKey
+  ansName?: string
+}
+
+export class AccountInfo extends Serializable {
+  readonly address: AccountAddress
+  readonly publicKey: PublicKey
+  readonly ansName?: string
+
+  constructor({ address, publicKey, ansName }: AccountInfoInput) {
+    super()
+    this.address = AccountAddress.from(address)
+    this.publicKey = publicKey
+    this.ansName = ansName
+  }
+
+  serialize(serializer: Serializer) {
+    this.address.serialize(serializer)
+    if (this.publicKey instanceof Ed25519PublicKey) {
+      serializer.serializeU32AsUleb128(SigningScheme.Ed25519)
+    } else if (this.publicKey instanceof MultiEd25519PublicKey) {
+      serializer.serializeU32AsUleb128(SigningScheme.MultiEd25519)
+    } else if (this.publicKey instanceof AnyPublicKey) {
+      serializer.serializeU32AsUleb128(SigningScheme.SingleKey)
+    } else if (this.publicKey instanceof MultiKey) {
+      serializer.serializeU32AsUleb128(SigningScheme.MultiKey)
+    } else {
+      throw new Error('Unsupported public key')
+    }
+    this.publicKey.serialize(serializer)
+    serializer.serializeStr(this.ansName ?? '')
+  }
+
+  static deserialize(deserializer: Deserializer) {
+    const address = AccountAddress.deserialize(deserializer)
+    const variant = deserializer.deserializeUleb128AsU32()
+    let publicKey: PublicKey
+    switch (variant) {
+      case SigningScheme.Ed25519:
+        publicKey = Ed25519PublicKey.deserialize(deserializer)
+        break
+      case SigningScheme.MultiEd25519:
+        publicKey = MultiEd25519PublicKey.deserialize(deserializer)
+        break
+      case SigningScheme.SingleKey:
+        publicKey = AnyPublicKey.deserialize(deserializer)
+        break
+      case SigningScheme.MultiKey:
+        publicKey = MultiKey.deserialize(deserializer)
+        break
+      default:
+        throw new Error(`Unknown variant index for WrappedPublicKey: ${variant}`)
+    }
+    const ansName = deserializer.deserializeStr() || undefined
+    return new AccountInfo({ address, publicKey, ansName })
+  }
+}

--- a/src/features/aptosConnect.ts
+++ b/src/features/aptosConnect.ts
@@ -1,7 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AccountInfo, NetworkInfo, UserResponse } from '../misc'
+import { AccountInfo } from '../AccountInfo'
+import { NetworkInfo, UserResponse } from '../misc'
 
 /** Version of the feature. */
 export type AptosConnectVersion = '1.0.0'

--- a/src/features/aptosGetAccount.ts
+++ b/src/features/aptosGetAccount.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AccountInfo } from '../misc'
+import { AccountInfo } from '../AccountInfo'
 
 /** Version of the feature. */
 export type AptosGetAccountVersion = '1.0.0'

--- a/src/features/aptosOnAccountChange.ts
+++ b/src/features/aptosOnAccountChange.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AccountInfo } from '../misc'
+import { AccountInfo } from '../AccountInfo'
 
 /** Version of the feature. */
 export type AptosOnAccountChangeVersion = '1.0.0'

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -5,12 +5,7 @@ import { AccountAddress, PublicKey, Network } from '@aptos-labs/ts-sdk'
 
 /** TODO: docs */
 export type TransactionHash = `0x${string}`
-/** TODO: docs */
-export type AccountInfo = {
-  address: AccountAddress
-  publicKey: PublicKey
-  ansName?: string
-}
+
 /** TODO: docs */
 export interface NetworkInfo {
   name: Network // Name of the network.


### PR DESCRIPTION
Added strongly typed and serializable `AccountInfo`.
This should take care of the problem of serializing public keys. 