### PR TITLE
Suppor transaction input and payload input for `signTransaction`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aptos-labs/wallet-standard",
   "description": "Aptos wallet standard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aptos-labs/wallet-standard",
   "bugs": {
@@ -32,8 +32,8 @@
   "scripts": {
     "clean": "rm -rf tsconfig.tsbuildinfo ./dist",
     "dev": "pnpm build --watch",
-    "build": "pnpm build:claer && tsup",
-    "build:claer": "rm -rf ./dist",
+    "build": "pnpm build:clear && tsup",
+    "build:clear": "rm -rf ./dist",
     "build:tsup": "tsup ./src/index.ts --format esm,cjs --sourcemap",
     "build:types": "tsc --build",
     "prepublishOnly": "pnpm build",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,6 @@
 export enum AptosWalletErrorCode {
   Unauthorized = 4100,
+  Unsupported = 4200,
   InternalError = -30001
 }
 
@@ -11,6 +12,10 @@ export const AptosWalletErrors = Object.freeze({
   [AptosWalletErrorCode.InternalError]: {
     status: 'Internal error',
     message: 'Something went wrong within the wallet.'
+  },
+  [AptosWalletErrorCode.Unsupported]: {
+    status: 'Unsupported',
+    message: 'The requested feature is not supported.'
   }
 })
 

--- a/src/features/aptosSignTransaction.ts
+++ b/src/features/aptosSignTransaction.ts
@@ -1,30 +1,82 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AnyRawTransaction, AccountAuthenticator } from '@aptos-labs/ts-sdk'
+import {
+  AccountAddress,
+  AccountAuthenticator,
+  AnyRawTransaction,
+  InputGenerateTransactionPayloadData,
+  Network,
+  PublicKey,
+  TransactionPayload
+} from '@aptos-labs/ts-sdk'
 import { UserResponse } from '../misc'
 
-/** Version of the feature. */
-export type AptosSignTransactionVersion = '1.0.0'
+// region Feature definition
+
 /** Name of the feature. */
 export const AptosSignTransactionNamespace = 'aptos:signTransaction'
-/**
- * A Wallet Standard feature for signing a Aptos transaction, and returning the
- * account authenticator.
- */
-export type AptosSignTransactionFeature = {
-  /** Namespace for the feature. */
+
+export type AptosSignTransactionFeatureV1_0 = {
   [AptosSignTransactionNamespace]: {
-    /** Version of the feature API. */
-    version: AptosSignTransactionVersion
+    version: '1.0.0',
     signTransaction: AptosSignTransactionMethod
   }
 }
+
+export type AptosSignTransactionFeatureV1_1 = {
+  [AptosSignTransactionNamespace]: {
+    version: '1.1'
+    signTransaction: AptosSignTransactionMethod & AptosSignTransactionMethodV1_1
+  }
+}
+
+/**
+ * A Wallet Standard feature for signing an Aptos transaction, and returning the
+ * account authenticator.
+ */
+export type AptosSignTransactionFeature =
+  AptosSignTransactionFeatureV1_0 | AptosSignTransactionFeatureV1_1;
+
+// endregion
+
+// region V1.0
+
+export type AptosSignTransactionOutput = AccountAuthenticator;
 
 export type AptosSignTransactionMethod = (
   transaction: AnyRawTransaction,
   asFeePayer?: boolean
 ) => Promise<UserResponse<AptosSignTransactionOutput>>
 
-/** Output of signing transactions. */
-export type AptosSignTransactionOutput = AccountAuthenticator
+// endregion
+
+// region V1.1
+
+export interface AccountInput {
+  address: AccountAddress;
+  publicKey?: PublicKey;
+}
+
+export interface AptosSignTransactionInputV1_1 {
+  expirationSecondsFromNow?: number; // defaults to 30 seconds (depends on wallet)
+  expirationTimestamp?: number;
+  feePayer?: AccountInput; // defaults to no fee payer
+  gasUnitPrice?: number; // defaults to estimated gas unit price
+  maxGasAmount?: number; // defaults to simulation result with fuzz factor
+  network?: Network; // defaults to active network
+  payload: TransactionPayload | InputGenerateTransactionPayloadData;
+  secondarySigners?: AccountInput[]; // defaults to no secondary signers
+  sender?: AccountInput; // defaulting to active account (if applicable)
+  sequenceNumber?: number | bigint; // defaulting to sender's sequence number
+  signerAddress?: AccountAddress;
+}
+
+export interface AptosSignTransactionOutputV1_1 {
+  authenticator: AccountAuthenticator;
+  rawTransaction: AnyRawTransaction;
+}
+
+export type AptosSignTransactionMethodV1_1 = (
+  input: AptosSignTransactionInputV1_1
+) => Promise<UserResponse<AptosSignTransactionOutputV1_1>>;


### PR DESCRIPTION
Part of a PR series to enable transaction input when using `signTransaction`

- https://github.com/aptos-labs/aptos-connect/pull/599
- https://github.com/aptos-labs/aptos-wallet-adapter/pull/414

Previously, the only supported input type was an `AnyRawTransaction` instance.

The problem with this is that we're requiring the dapp to generate the transaction (and possibly payload) right before calling `signTransaction`.

This requires async calls which don't play well with certain browsers and popups.
