### PR TITLE
[deps] Bump wallet-standard to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aptos-labs/wallet-standard",
   "description": "Aptos wallet standard",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aptos-labs/wallet-standard",
   "bugs": {


### PR DESCRIPTION
### Description

Bumped the wallet-standard to 0.3.0 to include the changes from this PR: https://github.com/aptos-labs/wallet-standard/pull/17