### PR TITLE
Release 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "dev": "tsc --watch",
     "build": "pnpm build:clear && tsc",
     "build:clear": "rm -rf ./dist",
-    "prepublishOnly": "pnpm build",
+    "typecheck": "tsc --noEmit",
+    "check:publish": "publint && attw --pack . --ignore-rules no-resolution cjs-resolves-to-esm",
+    "prepublishOnly": "pnpm build && pnpm check:publish",
     "format": "biome format --write .",
     "lint": "biome check .",
     "lint:fix": "biome check --write ."
@@ -41,7 +43,9 @@
     "@wallet-standard/core": "^1.0.3"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.2",
     "@biomejs/biome": "2.4.6",
+    "publint": "^0.3.21",
     "typescript": "^6.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aptos-labs/wallet-standard",
   "description": "Aptos wallet standard",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aptos-labs/wallet-standard",
   "bugs": {
@@ -9,8 +9,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "types": "./dist/index.d.ts",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.33.2",
   "engines": {
     "node": ">=22.0.0"
   },
@@ -38,7 +37,7 @@
     "lint:fix": "biome check --write ."
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^7.0.0",
+    "@aptos-labs/ts-sdk": "^7.0.1",
     "@wallet-standard/core": "^1.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,15 @@ importers:
         specifier: ^1.0.3
         version: 1.1.1
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.2
+        version: 0.18.2
       '@biomejs/biome':
         specifier: 2.4.6
         version: 2.4.6
+      publint:
+        specifier: ^0.3.21
+        version: 0.3.21
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -35,6 +41,9 @@ importers:
         version: 1.1.1
 
 packages:
+
+  '@andrewbranch/untar.js@1.0.3':
+    resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
 
   '@aptos-labs/aptos-cli@3.0.0':
     resolution: {integrity: sha512-fw9Ph6pe9l/RW6LMqjpxrHiWo2T/gtYWZsRxgl4PqVroavGF13YEQWlUnjJfWgVi1wQHpQcoJ1eYbYsPFu2sVg==}
@@ -54,6 +63,15 @@ packages:
   '@aptos-labs/ts-sdk@7.0.1':
     resolution: {integrity: sha512-kKO43zDsUaLzrNAqVV5eC4OG9ZDtCwaKwmX5S9iN0T4bF/HY1TU/zPoEJvfZGv8ztPeBixC7iVXqU4jNHZ3QFA==}
     engines: {node: '>=22.0.0'}
+
+  '@arethetypeswrong/cli@0.18.2':
+    resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@arethetypeswrong/core@0.18.2':
+    resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
+    engines: {node: '>=20'}
 
   '@biomejs/biome@2.4.6':
     resolution: {integrity: sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==}
@@ -112,6 +130,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@braidai/lang@1.1.2':
+    resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
+  '@loaderkit/resolve@1.0.5':
+    resolution: {integrity: sha512-fhkdGM57xhJ7CO91MUgbQlb0ClP0AJ9vB3yoVnBTslYJqrJOCVEbOprZcxZlexdMbmTBPQqVcQYr+j4oRRtIZA==}
+
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
@@ -124,6 +152,10 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
+
   '@scure/base@2.2.0':
     resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
@@ -132,6 +164,10 @@ packages:
 
   '@scure/bip39@2.2.0':
     resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
 
   '@wallet-standard/app@1.1.0':
     resolution: {integrity: sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==}
@@ -158,9 +194,62 @@ packages:
     resolution: {integrity: sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==}
     engines: {node: '>=16'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -170,15 +259,142 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
 
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
+  marked@9.1.6:
+    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
+    engines: {node: '>= 16'}
+    hasBin: true
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   poseidon-lite@0.3.0:
     resolution: {integrity: sha512-ilJj4MIve4uBEG7SrtPqUUNkvpJ/pLVbndxa0WvebcQqeIhe+h72JR4g0EvwchUzm9sOQDlOjiDNmRAgxNZl4A==}
+
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
@@ -189,7 +405,33 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
+
+  validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
 snapshots:
+
+  '@andrewbranch/untar.js@1.0.3': {}
 
   '@aptos-labs/aptos-cli@3.0.0':
     dependencies:
@@ -224,6 +466,27 @@ snapshots:
       eventemitter3: 5.0.4
       jwt-decode: 4.0.0
       poseidon-lite: 0.3.0
+
+  '@arethetypeswrong/cli@0.18.2':
+    dependencies:
+      '@arethetypeswrong/core': 0.18.2
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      commander: 10.0.1
+      marked: 9.1.6
+      marked-terminal: 7.3.0(marked@9.1.6)
+      semver: 7.8.0
+
+  '@arethetypeswrong/core@0.18.2':
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.3
+      '@loaderkit/resolve': 1.0.5
+      cjs-module-lexer: 1.4.3
+      fflate: 0.8.2
+      lru-cache: 11.3.6
+      semver: 7.8.0
+      typescript: 5.6.1-rc
+      validate-npm-package-name: 5.0.1
 
   '@biomejs/biome@2.4.6':
     optionalDependencies:
@@ -260,6 +523,15 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.6':
     optional: true
 
+  '@braidai/lang@1.1.2': {}
+
+  '@colors/colors@1.5.0':
+    optional: true
+
+  '@loaderkit/resolve@1.0.5':
+    dependencies:
+      '@braidai/lang': 1.1.2
+
   '@noble/ciphers@2.2.0': {}
 
   '@noble/curves@2.2.0':
@@ -267,6 +539,8 @@ snapshots:
       '@noble/hashes': 2.2.0
 
   '@noble/hashes@2.2.0': {}
+
+  '@publint/pack@0.1.4': {}
 
   '@scure/base@2.2.0': {}
 
@@ -280,6 +554,8 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.2.0
       '@scure/base': 2.2.0
+
+  '@sindresorhus/is@4.6.0': {}
 
   '@wallet-standard/app@1.1.0':
     dependencies:
@@ -308,18 +584,204 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.0
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  any-promise@1.3.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
+  cjs-module-lexer@1.4.3: {}
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@10.0.1: {}
 
   commander@13.1.0: {}
 
   commander@14.0.3: {}
 
+  emoji-regex@8.0.0: {}
+
+  emojilib@2.4.0: {}
+
+  environment@1.1.0: {}
+
+  escalade@3.2.0: {}
+
   eventemitter3@5.0.4: {}
+
+  fflate@0.8.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  has-flag@4.0.0: {}
+
+  highlight.js@10.7.3: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   jwt-decode@4.0.0: {}
 
+  lru-cache@11.3.6: {}
+
+  marked-terminal@7.3.0(marked@9.1.6):
+    dependencies:
+      ansi-escapes: 7.3.0
+      ansi-regex: 6.2.2
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 9.1.6
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
+  marked@9.1.6: {}
+
+  mri@1.2.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
+
+  object-assign@4.1.1: {}
+
+  package-manager-detector@1.6.0: {}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
+
+  picocolors@1.1.1: {}
+
   poseidon-lite@0.3.0: {}
+
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
+  require-directory@2.1.1: {}
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
+  semver@7.8.0: {}
+
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  typescript@5.6.1-rc: {}
 
   typescript@6.0.2: {}
 
   undici@7.25.0: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
+
+  validate-npm-package-name@5.0.1: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@5.0.8: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^7.0.1
+        version: 7.0.1
       '@wallet-standard/core':
         specifier: ^1.0.3
         version: 1.1.1
@@ -49,6 +49,10 @@ packages:
 
   '@aptos-labs/ts-sdk@7.0.0':
     resolution: {integrity: sha512-/gtKRewQScJ5RMvfPNd64poZdI0CF3qqkj48oEDNG07gb0i3mGadarCmu899KqeA47+nYFH7Lttkq+0PIMYGcQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@aptos-labs/ts-sdk@7.0.1':
+    resolution: {integrity: sha512-kKO43zDsUaLzrNAqVV5eC4OG9ZDtCwaKwmX5S9iN0T4bF/HY1TU/zPoEJvfZGv8ztPeBixC7iVXqU4jNHZ3QFA==}
     engines: {node: '>=22.0.0'}
 
   '@biomejs/biome@2.4.6':
@@ -196,6 +200,19 @@ snapshots:
       undici: 7.25.0
 
   '@aptos-labs/ts-sdk@7.0.0':
+    dependencies:
+      '@aptos-labs/aptos-cli': 3.0.0
+      '@aptos-labs/aptos-client': 4.0.0
+      '@noble/ciphers': 2.2.0
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      eventemitter3: 5.0.4
+      jwt-decode: 4.0.0
+      poseidon-lite: 0.3.0
+
+  '@aptos-labs/ts-sdk@7.0.1':
     dependencies:
       '@aptos-labs/aptos-cli': 3.0.0
       '@aptos-labs/aptos-client': 4.0.0

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,3 +1,6 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 import type { SigningScheme } from '@aptos-labs/ts-sdk'
 import type { WalletAccount } from '@wallet-standard/core'
 

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -21,8 +21,4 @@ export const APTOS_CHAINS = [
   APTOS_MAINNET_CHAIN
 ] as const
 
-export type AptosChain =
-  | typeof APTOS_DEVNET_CHAIN
-  | typeof APTOS_TESTNET_CHAIN
-  | typeof APTOS_LOCALNET_CHAIN
-  | typeof APTOS_MAINNET_CHAIN
+export type AptosChain = (typeof APTOS_CHAINS)[number]

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -11,12 +11,24 @@ import {
 import type { MinimallyRequiredFeatures } from './features/index.js'
 import type { AptosWallet } from './wallet.js'
 
-// These features are absolutely required for wallets to function in the Aptos ecosystem.
-// Eventually, as wallets have more consistent support of features, we may want to extend this list.
+// Namespaces of features that all Aptos wallets MUST implement. This is intentionally narrower
+// than `keyof MinimallyRequiredFeatures`, which also includes the optional `Partial<...>`
+// features from features/index.ts (signIn, signAndSubmitTransaction, changeNetwork,
+// openInMobileApp).
+type RequiredFeatureNamespace =
+  | 'aptos:account'
+  | 'aptos:connect'
+  | 'aptos:disconnect'
+  | 'aptos:network'
+  | 'aptos:onAccountChange'
+  | 'aptos:onNetworkChange'
+  | 'aptos:signMessage'
+  | 'aptos:signTransaction'
+
 // Each required feature is paired with the method name it must expose, so that a stub wallet
 // registering empty/null feature objects fails the check rather than passing the type predicate
 // and throwing later when the dApp invokes the missing method.
-const REQUIRED_FEATURE_METHODS: { readonly [K in keyof MinimallyRequiredFeatures]: string } = {
+const REQUIRED_FEATURE_METHODS = {
   'aptos:account': 'account',
   'aptos:connect': 'connect',
   'aptos:disconnect': 'disconnect',
@@ -25,7 +37,7 @@ const REQUIRED_FEATURE_METHODS: { readonly [K in keyof MinimallyRequiredFeatures
   'aptos:onNetworkChange': 'onNetworkChange',
   'aptos:signMessage': 'signMessage',
   'aptos:signTransaction': 'signTransaction'
-}
+} as const satisfies Record<RequiredFeatureNamespace, string>
 
 export function isWalletWithRequiredFeatureSet<AdditionalFeatures extends Wallet['features']>(
   wallet: Wallet,

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -13,24 +13,30 @@ import type { AptosWallet } from './wallet.js'
 
 // These features are absolutely required for wallets to function in the Aptos ecosystem.
 // Eventually, as wallets have more consistent support of features, we may want to extend this list.
-const REQUIRED_FEATURES: (keyof MinimallyRequiredFeatures)[] = [
-  'aptos:account',
-  'aptos:connect',
-  'aptos:disconnect',
-  'aptos:network',
-  'aptos:onAccountChange',
-  'aptos:onNetworkChange',
-  'aptos:signMessage',
-  'aptos:signTransaction'
-]
+// Each required feature is paired with the method name it must expose, so that a stub wallet
+// registering empty/null feature objects fails the check rather than passing the type predicate
+// and throwing later when the dApp invokes the missing method.
+const REQUIRED_FEATURE_METHODS: { readonly [K in keyof MinimallyRequiredFeatures]: string } = {
+  'aptos:account': 'account',
+  'aptos:connect': 'connect',
+  'aptos:disconnect': 'disconnect',
+  'aptos:network': 'network',
+  'aptos:onAccountChange': 'onAccountChange',
+  'aptos:onNetworkChange': 'onNetworkChange',
+  'aptos:signMessage': 'signMessage',
+  'aptos:signTransaction': 'signTransaction'
+}
 
 export function isWalletWithRequiredFeatureSet<AdditionalFeatures extends Wallet['features']>(
   wallet: Wallet,
   additionalFeatures: (keyof AdditionalFeatures)[] = []
 ): wallet is WalletWithFeatures<MinimallyRequiredFeatures & AdditionalFeatures> {
-  return [...REQUIRED_FEATURES, ...additionalFeatures].every(
-    (feature) => feature in wallet.features
-  )
+  for (const [feature, method] of Object.entries(REQUIRED_FEATURE_METHODS)) {
+    const impl = (wallet.features as Record<string, unknown>)[feature]
+    if (typeof impl !== 'object' || impl === null) return false
+    if (typeof (impl as Record<string, unknown>)[method] !== 'function') return false
+  }
+  return additionalFeatures.every((feature) => (feature as string) in wallet.features)
 }
 
 /**

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -45,18 +45,6 @@ export function getAptosWallets(): {
   ) => () => void
 } {
   const { get, on } = getWallets()
-
-  const wallets = get()
-
-  const aptosWallets: Wallet[] = []
-
-  wallets.forEach((wallet: Wallet) => {
-    const isAptos = isWalletWithRequiredFeatureSet(wallet)
-
-    if (isAptos) {
-      aptosWallets.push(wallet)
-    }
-  })
-
-  return { aptosWallets: aptosWallets as AptosWallet[], on }
+  const aptosWallets = get().filter((w) => isWalletWithRequiredFeatureSet(w)) as AptosWallet[]
+  return { aptosWallets, on }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,7 +4,7 @@ export enum AptosWalletErrorCode {
   InternalError = -30001
 }
 
-export const AptosWalletErrors = Object.freeze({
+export const AptosWalletErrors = {
   [AptosWalletErrorCode.Unauthorized]: {
     status: 'Unauthorized',
     message: 'The requested method and/or account has not been authorized by the user.'
@@ -17,7 +17,7 @@ export const AptosWalletErrors = Object.freeze({
     status: 'Unsupported',
     message: 'The requested feature is not supported.'
   }
-})
+} as const satisfies Record<AptosWalletErrorCode, { status: string; message: string }>
 
 export class AptosWalletError extends Error {
   readonly code: number

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,20 +4,20 @@ export enum AptosWalletErrorCode {
   InternalError = -30001
 }
 
-export const AptosWalletErrors = {
-  [AptosWalletErrorCode.Unauthorized]: {
+export const AptosWalletErrors = Object.freeze({
+  [AptosWalletErrorCode.Unauthorized]: Object.freeze({
     status: 'Unauthorized',
     message: 'The requested method and/or account has not been authorized by the user.'
-  },
-  [AptosWalletErrorCode.InternalError]: {
+  } as const),
+  [AptosWalletErrorCode.InternalError]: Object.freeze({
     status: 'Internal error',
     message: 'Something went wrong within the wallet.'
-  },
-  [AptosWalletErrorCode.Unsupported]: {
+  } as const),
+  [AptosWalletErrorCode.Unsupported]: Object.freeze({
     status: 'Unsupported',
     message: 'The requested feature is not supported.'
-  }
-} as const satisfies Record<AptosWalletErrorCode, { status: string; message: string }>
+  } as const)
+} as const) satisfies Record<AptosWalletErrorCode, { status: string; message: string }>
 
 export class AptosWalletError extends Error {
   readonly code: number

--- a/src/features/aptosSignAndSubmitTransaction.ts
+++ b/src/features/aptosSignAndSubmitTransaction.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { InputGenerateTransactionPayloadData } from '@aptos-labs/ts-sdk'
-import type { UserResponse } from '../misc.js'
+import type { TransactionHash, UserResponse } from '../misc.js'
 
 /** Version of the feature. */
 export type AptosSignAndSubmitTransactionVersion = '1.1.0'
@@ -32,5 +32,5 @@ export interface AptosSignAndSubmitTransactionInput {
 }
 
 export interface AptosSignAndSubmitTransactionOutput {
-  hash: string
+  hash: TransactionHash
 }

--- a/src/features/aptosSignIn.ts
+++ b/src/features/aptosSignIn.ts
@@ -127,6 +127,15 @@ export type AptosSignInBoundFields = {
 
 /**
  * Output fields from the `signIn` signing request to the wallet.
+ *
+ * @remarks
+ * **Security:** `input` is the wallet's self-reported claim of which fields were
+ * incorporated into the signed message. Relying parties MUST reconstruct the SIWA
+ * signing message from `input` and verify `signature` against `account.publicKey`
+ * before trusting any field in `input`. In particular, do not use `input.address`
+ * as the authenticated address — derive it from `account.publicKey`. A malicious
+ * wallet can return any values it likes in `input`; only fields whose values are
+ * covered by a valid `signature` should be trusted.
  */
 export type AptosSignInOutput = {
   /**

--- a/src/features/aptosSignMessage.ts
+++ b/src/features/aptosSignMessage.ts
@@ -30,6 +30,17 @@ export type AptosSignMessageInput = {
   nonce: string
 }
 
+/**
+ * @remarks
+ * **Security:** Every field other than `signature` is the wallet's self-reported
+ * claim of what was signed. Relying parties MUST verify `signature` against the
+ * connected account's public key over `fullMessage`, and MUST confirm that
+ * `fullMessage` actually incorporates the fields the dApp requested via
+ * `AptosSignMessageInput` (e.g., if `input.address === true`, the dApp should
+ * verify that the expected address appears in `fullMessage`). A malicious wallet
+ * can omit requested bindings, substitute values, or return a `fullMessage` that
+ * differs from what `address` / `application` / `chainId` claim.
+ */
 export type AptosSignMessageOutput = {
   address?: string
   application?: string

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -6,9 +6,22 @@ import type { Network } from '@aptos-labs/ts-sdk'
 export type TransactionHash = `0x${string}`
 
 export interface NetworkInfo {
-  name: Network // Name of the network.
-  chainId: number // Chain ID of the network.
-  url?: string // RPC URL of the network.
+  /** Name of the network. */
+  name: Network
+  /** Chain ID of the network. */
+  chainId: number
+  /**
+   * RPC URL of the network. Should be an `https:` URL.
+   *
+   * @remarks
+   * **Security:** When returned by a wallet (e.g., from `aptos:network` or
+   * `aptos:onNetworkChange`), this value is wallet-supplied and not validated by
+   * this library. Consumers that use this URL to issue RPC calls MUST validate
+   * the scheme and authority against an allowlist for the claimed `chainId`;
+   * otherwise a malicious wallet can redirect on-chain reads and transaction
+   * submission to an attacker-controlled node.
+   */
+  url?: string
 }
 
 export enum UserResponseStatus {

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -5,7 +5,14 @@ import type { WalletWithAptosFeatures } from './features/index.js'
 
 export interface AptosWallet extends WalletWithAptosFeatures {
   /**
-   * Website URL of the Wallet
+   * Website URL of the Wallet. Should be an `https:` URL.
+   *
+   * @remarks
+   * **Security:** This value is supplied by the wallet itself when it self-registers
+   * with `@wallet-standard/core`. It is not validated by this library. Consumers
+   * that render this URL as a link or pass it to `window.open()` MUST validate the
+   * scheme (e.g., reject anything other than `https:`) to avoid `javascript:`
+   * URI injection from a malicious wallet.
    */
   readonly url: string
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "moduleDetection": "force",
     "moduleResolution": "NodeNext",
     "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "rootDir": "./src",
     "outDir": "./dist",
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Prepares the `@aptos-labs/wallet-standard` package for a 2.0.0 major release. Three logical changes:

1. **Type and ESM publish hygiene** — tighten the public surface and the publish artifact.
2. **Release gate** — wire publint and arethetypeswrong into `prepublishOnly` so a misconfigured publish fails before reaching the registry.
3. **Security audit fixes** — close gaps surfaced by an internal audit of the trust boundary between dApps and wallets.

No breaking runtime changes are intended. The TypeScript-visible API tightens in a few places (stricter `noUncheckedIndexedAccess`, a brand on a transaction hash field, a derived union for chains) but no public symbol is removed or renamed.

## What changed

### `[2.0.0] Tighten types and ESM publish hygiene` (`83c0813`)

- Version bump 1.0.0 → 2.0.0.
- `AptosChain` is now derived from `APTOS_CHAINS` via `(typeof APTOS_CHAINS)[number]` instead of a hand-maintained 4-arm union, so adding a chain stays a one-line edit.
- `getAptosWallets` collapsed from a `forEach`/`push` loop into a single `filter` call.
- `AptosWalletErrors` table changed from `Object.freeze({...})` to `{...} as const satisfies Record<AptosWalletErrorCode, { status: string; message: string }>`. This gives deep readonly types and literal narrowing (vs. shallow runtime locking) and adds a `satisfies` shape check that will fail at this file if a new error code is added without a corresponding row.
- Added missing SPDX copyright header to `src/account.ts` for consistency with every other source file.
- Enabled `noUncheckedIndexedAccess` and `noImplicitOverride` in `tsconfig.json`.
- Dropped the top-level `"types"` field in `package.json`; modern resolvers read it from the `exports` map and the redundant top-level field only mattered for legacy `moduleResolution: node`, which is incompatible with this package's `exports`-only setup anyway.
- Bumped `@aptos-labs/ts-sdk` peer to `^7.0.1` and `packageManager` to `pnpm@10.33.2`.

### `[ci] Add publint and arethetypeswrong release gate` (`c10a65a`)

- Added `publint` and `@arethetypeswrong/cli` as dev dependencies.
- New `check:publish` script runs both tools. `prepublishOnly` now runs `pnpm build && pnpm check:publish`, so an incorrectly-published package fails locally before any `npm publish` attempt.
- New `typecheck` script (`tsc --noEmit`) provides a fast type-only verification path for CI/pre-commit, separate from full build.
- Two `attw` rules are deliberately ignored:
  - `no-resolution` — node10 cannot read `exports` maps. We require Node 22, so this failure mode is the intended contract.
  - `cjs-resolves-to-esm` — this package is ESM-only by design. CJS consumers using dynamic `import()` is the documented path.

### `[security] Address audit findings for 2.0.0` (`f4573e8`)

- **`isWalletWithRequiredFeatureSet`** now verifies that each required feature's primary method (`connect`, `signTransaction`, etc.) is actually a function, not just that the namespace key exists. A stub wallet registering `{ 'aptos:connect': null }` previously passed the type predicate and crashed at call time; it now fails the check.
- **`AptosSignAndSubmitTransactionOutput.hash`** is typed as `TransactionHash` (the existing `` `0x${string}` `` brand from `misc.ts`) instead of a bare `string`. dApps that pass an unprefixed value back to the SDK now get a type error.
- Added `@remarks` security blocks to **`AptosSignInOutput`**, **`AptosSignMessageOutput`**, **`AptosWallet.url`**, and **`NetworkInfo.url`** documenting that those wallet-supplied fields are claims that must be independently verified (signature verification, URL scheme validation, RPC allowlists) before they can be trusted. These are documentation fixes — the library cannot physically prevent a malicious wallet from lying, but it can stop misleading dApp authors about what `output.input.address` means.

## Out of scope

- **BCS encoding of `AccountInfo.ansName`**: `serialize` currently uses `serializeStr(this.ansName ?? '')`, so `undefined` and `""` produce identical bytes. Moving to `serializeOption` would be the correct fix but is a wire-format break. Deferred since empty ANS names are not expected in practice. Worth revisiting if `AccountInfo` bytes are ever stored or transmitted across versions.
- TS `target` bump from ES2022 to ES2023 was considered and rejected for conservatism (Safari 15 era still common in some browser-extension wallets); emit is identical at the current call sites.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (biome)
- [x] `pnpm build` — clean
- [x] `pnpm check:publish` — publint "All good!" and attw "No problems found 🌟" across `node10`, `node16 (from CJS)`, `node16 (from ESM)`, and `bundler` (with the two ESM-intent rules ignored)
- [ ] Manual: tag and publish to npm — deferred until after merge