### PR TITLE
chore: prepare CHANGELOG for v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the aptos-wallet-standard tool will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Unreleased
+
+- No changes yet.
+
 # 2.0.0 (2026-05-21)
 
 - Add **Vitest** test runner with V8 coverage (`pnpm test`, `pnpm test:watch`, `pnpm test:coverage`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the aptos-wallet-standard tool will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-# Unreleased
+# 2.0.0 (2026-05-21)
 
 - Add **Vitest** test runner with V8 coverage (`pnpm test`, `pnpm test:watch`, `pnpm test:coverage`).
 - Add unit tests covering the public behaviors of the package: `AccountInfo` BCS wire format and round-trip for every `SigningScheme` variant, `detect.isWalletWithRequiredFeatureSet` / `getAptosWallets` filtering, `AptosWalletError` invariants, and the externally observable chain identifiers, feature namespaces, and `UserResponseStatus` values.


### PR DESCRIPTION
## Summary

- Promotes the `# Unreleased` section in `CHANGELOG.md` to `# 2.0.0 (2026-05-21)`
- `package.json` is already at `2.0.0` — no version bump needed

## After merging

1. Create an annotated tag on `main`:
   ```bash
   git checkout main && git pull
   git tag -a v2.0.0 -m "v2.0.0"
   git push origin v2.0.0
   ```
2. On GitHub, create a Release from tag `v2.0.0` and publish it — this triggers `publish.yml` which builds and publishes `@aptos-labs/wallet-standard@2.0.0` to npm.