### PR TITLE
ci: fix OIDC publishing by removing registry-url from setup-node

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           node-version: "22"
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install --frozen-lockfile
 
@@ -74,5 +73,3 @@ jobs:
           npm --version
 
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `actions/setup-node` in the publish workflow
- Remove the now-unnecessary `NODE_AUTH_TOKEN` env var from the publish step

## Why

`actions/setup-node` with `registry-url` writes an `.npmrc` that contains `_authToken=${NODE_AUTH_TOKEN}`. Even when `NODE_AUTH_TOKEN` is empty, this entry prevents npm from falling through to its automatic OIDC token exchange, resulting in `ENEEDAUTH`.

Removing `registry-url` lets npm detect the GitHub Actions OIDC environment (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) and authenticate via the trusted publisher configured on npmjs.com — no stored secret needed.

## Test plan

- [ ] Merge to main
- [ ] Re-run the failed `Publish to npm` workflow (or re-publish the v2.0.0 release)
- [ ] Confirm `npm publish --provenance` succeeds via OIDC