### PR TITLE
ci: bump pinned npm to 11.5.1 for OIDC tokenless publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Upgrade npm (bundled npm is broken on this runner image)
         env:
           # Pinned for reproducibility; bump deliberately when a newer npm is needed.
-          NPM_VERSION: "11.4.2"
+          # 11.5.1+ is required: earlier versions lack lib/utils/oidc.js (OIDC tokenless publishing).
+          NPM_VERSION: "11.5.1"
         run: |
           metadata=$(curl -fsS "https://registry.npmjs.org/npm/${NPM_VERSION}")
           tarball_url=$(echo "$metadata" | node -p 'JSON.parse(require("fs").readFileSync(0,"utf8")).dist.tarball')


### PR DESCRIPTION
## Summary

- Bump the pinned npm version in the publish workflow from `11.4.2` → `11.5.1`
- Add a comment documenting why this minimum version matters

## Why

`npm 11.4.2` does not ship `lib/utils/oidc.js`, the module that performs the GitHub OIDC → npm token exchange required for tokenless trusted publishing. We verified this locally (`oidc.js MISSING` on 11.4.2, `oidc.js EXISTS` on 11.5.1).

Without this module, npm silently skips the OIDC exchange and falls through to `ENEEDAUTH`, regardless of the trusted publisher configuration on npmjs.com or the `id-token: write` permission on the job.

The integrity check in the upgrade step fetches the expected hash dynamically from the registry, so no hardcoded hash needs updating here.

## Test plan

- [ ] Merge to main
- [ ] Redo the v2.0.0 tag + release
- [ ] Confirm `Publish to npm` workflow completes successfully via OIDC (no `NPM_TOKEN` secret needed)