### PR TITLE
pkg: add repository field required for provenance verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "2.0.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aptos-labs/wallet-standard",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aptos-labs/wallet-standard"
+  },
   "bugs": {
     "url": "https://github.com/aptos-labs/wallet-standard/issues/new/choose"
   },


### PR DESCRIPTION
## Summary

- Add `repository` field to `package.json` pointing at `https://github.com/aptos-labs/wallet-standard`

## Why

`npm publish --provenance` embeds the GitHub repo URL from the Actions context into the signed attestation and then asks the npm registry to verify it. The registry checks that `package.json#repository.url` matches — if the field is absent or empty it returns:

```
E422 Unprocessable Entity: Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/aptos-labs/wallet-standard"
```

OIDC auth itself succeeded (progress from the previous `ENEEDAUTH`); this is the last blocker before v2.0.0 publishes.

## Test plan

- [ ] Merge to main
- [ ] Redo the v2.0.0 tag + release
- [ ] Confirm `Publish to npm` workflow succeeds